### PR TITLE
Fixed an issue with the expected content length

### DIFF
--- a/hda/api.py
+++ b/hda/api.py
@@ -436,6 +436,9 @@ class Client(object):
 
                 self.debug("Headers: %s", r.headers)
 
+                # https://github.com/ecmwf/hda/issues/3
+                size = int(r.headers.get('Content-Length', size))
+
                 with tqdm(total=size,
                           unit_scale=True,
                           unit_divisor=1024,


### PR DESCRIPTION
This will change the way the content length is retrieved, using the Content-Length header in the first place and then the returned "size" value as a fallback.
Not only this will solve the unexpected warning at the end of the download, but can also avoid more serious issues as "416 Client Error: Requested Range Not Satisfiable"