### PR TITLE
Fixed download filename

### DIFF
--- a/hda/api.py
+++ b/hda/api.py
@@ -436,6 +436,9 @@ class Client(object):
 
                 self.debug("Headers: %s", r.headers)
 
+                # https://github.com/ecmwf/hda/issues/3
+                size = int(r.headers.get('Content-Length', size))
+
                 with tqdm(total=size,
                           unit_scale=True,
                           unit_divisor=1024,


### PR DESCRIPTION
For a large number of datasets (mostly from Mercator Ocean), the provided filename starts with a portion of a query string:
eg: **&service=SST_GLO_SST_L4_REP_OBSERVATIONS_010_011-TDS...**

In this case, the file name should be retrieved from the `Location` header of the redirect response.
In the example above, the file name is **METOFFICE-GLO-SST-L4-REP-OBS-SST_1638355890887.nc**
This mechanism is reusable for other cases, but it is not always safe - namely not for Cryosat or other ESA datasets.