### PR TITLE
added method to allow licence acceptance through client

### DIFF
--- a/hda/api.py
+++ b/hda/api.py
@@ -319,6 +319,11 @@ class Client(object):
 
         return self._session
 
+    def accept_licence(self):
+        full = self.full_url("termsaccepted/Copernicus_General_License")
+        r = requests.put(full, headers=self.session.headers, data={"accepted": "true"})
+        self.info("===> LICENCE %s", "accepted")
+
     def info(self, *args, **kwargs):
         if self.info_callback:
             self.info_callback(*args, **kwargs)


### PR DESCRIPTION
First contribute;

API client can not currently be used to accept Copernicus licence, which is a little inconvenient. Added a small method to allow this. Tested on a dummy user account, but a little tricky as licence conditions are sticky (e.g. cannot be reset to false) so only tested once. Warrants further testing.