### PR TITLE
Refreshed token

### DIFF
--- a/hda/api.py
+++ b/hda/api.py
@@ -207,7 +207,7 @@ class Client(object):
         user=os.environ.get("HDA_USER"),
         password=os.environ.get("HDA_PASSWORD"),
         token=os.environ.get("HDA_TOKEN"),
-        token_timeout=60*45,
+        token_timeout=60 * 45,
         quiet=False,
         debug=False,
         verify=None,
@@ -307,8 +307,10 @@ class Client(object):
         now = int(time.time())
 
         def is_token_expired():
-            return self._token_creation_time is None or \
-                (now - self._token_creation_time) > self.token_timeout
+            return (
+                self._token_creation_time is None
+                or (now - self._token_creation_time) > self.token_timeout
+            )
 
         if is_token_expired():
             self.debug("====== Token expired, renewing")


### PR DESCRIPTION
Added a simple check on expired tokens each time the authorization header gets added to the session.
The check is pre-emptively done by storing the presumed timeout.
To actually check whether the token is 