### PR TITLE
download_dir is created automatically. Bumped version

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+Version 1.14
+-------------
+* The `download_dir` is created automatically
+
 Version 1.13
 -------------
 * Minor documentation fixes

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,8 +15,8 @@ project = "WEkEO HDA API Client"
 copyright = "2023, ECMWF"
 author = "ECMWF"
 
-release = "1.13"
-version = "1.13"
+release = "1.14"
+version = "1.14"
 
 # -- General configuration
 

--- a/hda/api.py
+++ b/hda/api.py
@@ -716,8 +716,10 @@ class Client(object):
             # always safe - namely not for Cryosat or other ESA datasets.
             filename = None
 
-        if download_dir is None or not os.path.exists(download_dir):
+        if download_dir is None:
             download_dir = "."
+        else:
+            os.makedirs(download_dir, exist_ok=True)
 
         logger.info(
             "Downloading %s to %s (%s)",

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ def read(fname):
     return io.open(file_path, encoding="utf-8").read()
 
 
-version = "1.13"
+version = "1.14"
 
 setuptools.setup(
     name="hda",


### PR DESCRIPTION
The download_dir parameter by default was set to the current directory if non-existent. Now the client tries to create the one passed in by the user. 