### PR TITLE
Removed URL parameter from .hdarc file

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -6,7 +6,7 @@ name: Upload Python Package
 on:
 
   push: {}
-  
+
   pull_request: {}
 
   release:
@@ -17,7 +17,7 @@ jobs:
     name: Code QA
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - run: pip install black flake8 isort
       - run: black --version
       - run: isort --version
@@ -38,7 +38,7 @@ jobs:
     needs: quality
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v2
         with:
@@ -63,7 +63,7 @@ jobs:
     needs: checks
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up Python
       uses: actions/setup-python@v2

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+Version 2.12
+-----------
+* Removed URL reading from file .hdarc
+
 Version 2.0
 -----------
 * Updated version compatible with HDA v2

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+Version 2.13
+-----------
+* Fixed missing exception case that could lead to empty files
+
 Version 2.12
 -----------
 * Removed URL reading from file .hdarc

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,8 +15,8 @@ project = "WEkEO HDA API Client"
 copyright = "2023, ECMWF"
 author = "ECMWF"
 
-release = "2.12"
-version = "2.12"
+release = "2.13"
+version = "2.13"
 
 # -- General configuration
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,8 +15,8 @@ project = "WEkEO HDA API Client"
 copyright = "2023, ECMWF"
 author = "ECMWF"
 
-release = "2.11"
-version = "2.11"
+release = "2.12"
+version = "2.12"
 
 # -- General configuration
 

--- a/hda/api.py
+++ b/hda/api.py
@@ -767,7 +767,7 @@ class Client(object):
                                 total += len(chunk)
                                 pbar.update(len(chunk))
 
-            except requests.exceptions.ConnectionError as e:
+            except requests.exceptions.RequestException as e:
                 logger.error("Download interrupted: %s" % (e,))
             finally:
                 r.close()

--- a/hda/api.py
+++ b/hda/api.py
@@ -317,14 +317,12 @@ class Configuration:
         url=os.environ.get("HDA_URL"),
         user=os.environ.get("HDA_USER"),
         password=os.environ.get("HDA_PASSWORD"),
-        verify=None,
+        verify=True,
         path=None,
     ):
         credentials = {
-            "url": url or BROKER_URL,
             "user": None,
-            "password": None,
-            "verify": True,
+            "password": None
         }
 
         dotrc = path or os.environ.get("HDA_RC", os.path.expanduser("~/.hdarc"))
@@ -336,25 +334,19 @@ class Configuration:
                 if config.get(key):
                     credentials[key] = config.get(key)
 
-        if url is not None:
-            credentials["url"] = url
-
         if user is not None:
             credentials["user"] = user
 
         if password is not None:
             credentials["password"] = password
 
-        if verify is not None:
-            credentials["verify"] = verify
-
         if credentials["user"] is None or credentials["password"] is None:
             raise ConfigurationError("Missing or incomplete configuration")
 
-        self.url = credentials["url"]
+        self.url = url or BROKER_URL
         self.user = credentials["user"]
         self.password = credentials["password"]
-        self.verify = credentials["verify"]
+        self.verify = verify
 
 
 class Client(object):

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ def read(fname):
     return io.open(file_path, encoding="utf-8").read()
 
 
-version = "2.12"
+version = "2.13"
 
 setuptools.setup(
     name="hda",

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ def read(fname):
     return io.open(file_path, encoding="utf-8").read()
 
 
-version = "2.11"
+version = "2.12"
 
 setuptools.setup(
     name="hda",

--- a/tests/custom_config.txt
+++ b/tests/custom_config.txt
@@ -1,3 +1,2 @@
-url: TESTURL
 user: TESTUSER
 password: TESTPASSWORD

--- a/tests/test_hda.py
+++ b/tests/test_hda.py
@@ -64,7 +64,6 @@ def test_custom_path_config():
 def test_mixed_config():
     config = Configuration(user="TU", password="TP", path=CUSTOM_HDRRC)
     c = Client(config=config)
-    assert c.config.url == "TESTURL"
     assert c.config.user == "TU"
     assert c.config.password == "TP"
 

--- a/tests/test_hda.py
+++ b/tests/test_hda.py
@@ -56,7 +56,6 @@ def test_custom_password_config():
 def test_custom_path_config():
     config = Configuration(user=None, password=None, path=CUSTOM_HDRRC)
     c = Client(config=config)
-    assert c.config.url == "TESTURL"
     assert c.config.user == "TESTUSER"
     assert c.config.password == "TESTPASSWORD"
 


### PR DESCRIPTION
Many users complain about authentication issues on v2 because the old .hdarc file might contain a no longer valid data broker URL.
Since the ability to set a custom URL is mainly used only for debugging or development purposes, it is no longer read from the file, so that users can keep their old files without changing them.

Moreover, some adapters showed erratic behavior (invalid chunk length) with very close download requests that led to empty files. Now the download function has a broader family of exceptions caught, and the retry system takes care of the rest. 