### PR TITLE
Serverless function

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+Version 2.18
+------------
+* Download URL computation has its own method
+
 Version 2.17
 -----------
 * Added Conda-Forge repository

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,8 +15,8 @@ project = "WEkEO HDA API Client"
 copyright = "2023, ECMWF"
 author = "ECMWF"
 
-release = "2.17"
-version = "2.17"
+release = "2.18"
+version = "2.18"
 
 # -- General configuration
 

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ def read(fname):
     return io.open(file_path, encoding="utf-8").read()
 
 
-version = "2.17"
+version = "2.18"
 
 setuptools.setup(
     name="hda",


### PR DESCRIPTION
I introduced a utility function to compute the download URL from the HDA without actually download a result.
This is necessary in the context of the Serverless Function service, which is expecting such URLs as inputs for either Snap or Datatailor.