### PR TITLE
Minor addition to api.py to expand userhome path

### DIFF
--- a/hda/api.py
+++ b/hda/api.py
@@ -750,7 +750,9 @@ class Client(object):
         :type download_dir: str
         """
         full = self.full_url(*[f"dataaccess/download/{download_id}"])
-
+        
+        download_dir = os.path.expanduser(download_dir)
+        
         if download_dir is None:
             download_dir = "."
         else:


### PR DESCRIPTION
Added one line for path expansion on userhome (os.path.expanduser(download_dir) - mainly relevant for linux/macos