### PR TITLE
Add automatic query expansion to the various product types available for a dataset (please check if sensible), addressing partially #37

### DIFF
--- a/hda/api.py
+++ b/hda/api.py
@@ -675,32 +675,31 @@ class Client(object):
         if "constraints" in response:
             del response["constraints"]
         return response
-        
+
     def product_types(self, dataset_id):
         """Returns a dict of the form {product_type_key: product types}
-        available for a given dataset with the dataset_id as the 
+        available for a given dataset with the dataset_id as the
         product_type_key varies between different datasets. Intended
         to be used in conjunction with a search for specific product
         types afterwards.
-        Returns an empty dict if no product types could be found. 
-        It internally uses the metadata(dataset_id) function to 
-        retrieve the product types, which might change in the future. 
+        Returns an empty dict if no product types could be found.
+        It internally uses the metadata(dataset_id) function to
+        retrieve the product types, which might change in the future.
+        :params dataset_id: The dataset ID
+        :type dataset_id: str
         Example usage:
         import hda
         client = hda.client()
         dataset_id = 'EO:EEA:DAT:HRL:GRA'
         product_types = client.product_types(dataset_id)
         print(f"Product types for {dataset_id}: {product_types}")
-        
-        :params dataset_id: The dataset ID
-        :type dataset_id: str
         """
         dataset_id, result = dataset_id.strip().upper(), {}
         meta = self.metadata(dataset_id)
         # only do this if everything is a dict the props are set
         if (not isinstance(meta, dict)
-            and 'properties' not in meta.keys()
-            and not isinstance(meta['properties'], dict)):
+                and 'properties' not in meta.keys()
+                and not isinstance(meta['properties'], dict)):
             return result
 
         product_key = None

--- a/hda/api.py
+++ b/hda/api.py
@@ -637,12 +637,12 @@ class Client(object):
                 if limit is not None and len(results) >= limit:
                     break
                 logger.debug("Searching for layer %s", layer)
-                _query = query.copy(); _query.update({product_key: layer})
+                _query = query.copy()
+                _query.update({product_key: layer})
                 results += list(SearchPaginator(self.post).run(query=_query, limit=limit))
-            
+
             results = results[:limit] if limit is not None else results
             return SearchResults(self, results, query["dataset_id"])
-            
 
     def datasets(self, limit=None):
         """Returns the full list of available datasets.
@@ -700,11 +700,10 @@ class Client(object):
         # only do this if everything is a dict the props are set
         if (not isinstance(meta, dict)
             and 'properties' not in meta.keys()
-            and not isinstance(meta['properties'], dict)
-           ):
+            and not isinstance(meta['properties'], dict)):
             return result
-        
-        product_key = None    
+
+        product_key = None
         # have to figure out the actual product key, could also use regex
         # but the number of property entries are limited in any case
         for key in meta['properties'].keys():
@@ -714,7 +713,7 @@ class Client(object):
                 product_key = key
                 # do not look for another product type (hopefully correct)
                 break
-                           
+
         if product_key is None:
             return result
         else:

--- a/hda/api.py
+++ b/hda/api.py
@@ -719,7 +719,8 @@ class Client(object):
             return result
         else:
             product_types = meta['properties'][product_key]
-            product_types = [i.get('const', None) for i in product_types.get('oneOf', {})]]
+            product_types = [i.get('const', None) for i in product_types.get('oneOf', {})]
+            product_types = sorted([i for i in product_types if i is not None])
             return {product_key: product_types}
 
     def get(self, *args, **kwargs):


### PR DESCRIPTION
### Description
This PR adds the function product_types(dataset_id) to extract the available product type keys (which is not standardised and may be productType, product_type or something else) by checking if both product and type are contained in the key from the metadata properties field.
This PR also implements a check for the function search(query) to see if a given query has a product type like entry and if not it will use the function product_types(dataset_id) to iterate over all available layers in the dataset. If a limit is given, the search may not look for all product types but only until limit is reached.
It is crucial to check before accepting this PR if 
  1. all datasets will contain some form of product type
  2. the intent of the search is as wanted by the package providers as it appears that the API now searches all productType and this work was done before this behaviour was the case (see #37). If so, the additional code in the search could be removed.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 