### PR TITLE
Check for error in response when requesting auth token

### DIFF
--- a/hda/api.py
+++ b/hda/api.py
@@ -477,6 +477,10 @@ class Client(object):
         if is_token_expired():
             logger.debug("====== Token expired, renewing")
             payload = self._get_token()
+            if 'error' in payload:
+                logger.debug("Token payload: %s", shorten(payload))
+                raise ConfigurationError(payload["error_description"])
+            
             self._access_token = payload["access_token"]
             self._refresh_token = payload["refresh_token"]
             self._token_expiration = now + payload["expires_in"]


### PR DESCRIPTION
### Description

If the user enters incorrect credentials for the API, the `Client.token()` function which makes the token request completes without error but causes subsequent functions to fail with incomplete/misleading error messages. This change checks the response from the token request for an `error` entry and, if it finds it, raises an error reporting the error description to the user

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 